### PR TITLE
fix issue in regex for parsing segment definition

### DIFF
--- a/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/UnEdifactMessage.java
+++ b/ect/src/main/java/org/smooks/edi/ect/formats/unedifact/UnEdifactMessage.java
@@ -77,7 +77,7 @@ public class UnEdifactMessage {
      * Group4 = isMandatory
      * Group5 = max occurance
      */                  
-    private static String SEGMENT_REGULAR = "(\\d{4,5})*[-\\+\\* XS]*(\\w{3}) *(.*) +(M|C|m|c) *(\\d+)[ \\|]*";
+    private static String SEGMENT_REGULAR = "(\\d{4,5})*[-\\+\\* XS]*(\\w{3}) *(.*)(M|C|m|c) *(\\d+)[ \\|]*";
 
     /**
      * Extracts information from Regular segment definition.


### PR DESCRIPTION
Remove the mandatory space between the name and the M|C
https://github.com/smooks/smooks-edi-cartridge/issues/26